### PR TITLE
[FIX] Use a PAT to enable workflows

### DIFF
--- a/.github/workflows/sync_forks.yml
+++ b/.github/workflows/sync_forks.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
         - name: Sync Forks
           env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_TOKEN: ${{ secrets.ON_WF_PAT }}
           run: |
             nRepos=$(gh api graphql -f query='{
                 organization(login: "OpenNeuroDatasets-JSONLD" ) {


### PR DESCRIPTION
We are running workflows across repositories.
For this we need a personal access token.
This PR adds one.