### PR TITLE
[ENH] Update CLI commands to work with latest `bagel` version and make session paths dataget-compatible

### DIFF
--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -70,6 +70,14 @@ jobs:
           path: code/data/jsonld
           # TODO: Add a retention policy to delete old artifacts
 
+      - name: Upload failed BIDS metadata tables if any
+        uses: actions/upload-artifact@v4
+        with:
+          name: failed-bids-tsvs
+          # NOTE: code/data/failed_bids_tsv is a temporary directory created by code/run_cli_single_dataset.sh
+          path: code/data/failed_bids_tsv
+          if-no-files-found: ignore
+
       - name: Upload log file as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jsonld-files
+          # NOTE: code/data/jsonld is a temporary directory created by code/run_cli_single_dataset.sh
           path: code/data/jsonld
           # TODO: Add a retention policy to delete old artifacts
 

--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,2 +1,2 @@
-bagel==0.6.0
+bagel
 datalad

--- a/code/run_cli_single_dataset.sh
+++ b/code/run_cli_single_dataset.sh
@@ -15,7 +15,7 @@ mkdir -p ${ldout}
 
 # NOTE: realpath is used to get an absolute path of the directory
 workdir=$(realpath ${ldin}/${ds_id})
-out="${ldout}/${ds_id}.jsonld"
+out_jsonld_path="${ldout}/${ds_id}.jsonld"
 
 datalad clone ${ds_portal} ${workdir}
 datalad get -d $workdir "${workdir}/participants.tsv"
@@ -39,6 +39,19 @@ if [ -z "$ds_name" ] || [ "$ds_name" == "null" ] || [[ "$ds_name" =~ ^[[:space:]
 fi
 
 # Run the Neurobagel CLI
-bagel pheno --pheno ${workdir}/participants.tsv --dictionary ${workdir}/participants.json --output ${workdir}/pheno.jsonld --name "$ds_name" --portal $ds_portal
-bagel bids --jsonld-path ${workdir}/pheno.jsonld  --input-bids-dir ${workdir} --source-bids-dir ${workdir} --output ${workdir}/pheno_bids.jsonld
-cp ${workdir}/pheno_bids.jsonld ${out}
+bagel pheno \
+    --pheno ${workdir}/participants.tsv \
+    --dictionary ${workdir}/participants.json \
+    --output ${workdir}/pheno.jsonld \
+    --name "$ds_name" \
+    --portal $ds_portal
+
+bagel bids2tsv --bids-dir ${workdir} --output ${workdir}/bids.tsv
+
+bagel bids \
+    --jsonld-path ${workdir}/pheno.jsonld \
+    --bids-table ${workdir}/bids.tsv \
+    --dataset-source-dir "/${ds_id}" \  # dataget expects OpenNeuro imaging session paths to be in the format /dsXXXX/sub-XXX/ses-XXX
+    --output ${workdir}/pheno_bids.jsonld
+
+cp ${workdir}/pheno_bids.jsonld ${out_jsonld_path}


### PR DESCRIPTION
See also https://miro.com/app/board/uXjVJIx8gak=/?share_link_id=260152752786 for diagram of cronjob workflow to run CLI on OpenNeuroDatasets-JSONLD repos.

- Closes #35
- Related to #32 