### PR TITLE
[ENH] Make CLI runner workflows smarter about which datasets to run the CLI on

### DIFF
--- a/.github/workflows/run_cli_on_all_repos.yml
+++ b/.github/workflows/run_cli_on_all_repos.yml
@@ -52,5 +52,6 @@ jobs:
       needs: get-repos
       uses: OpenNeuroDatasets-JSONLD/.github/.github/workflows/run_cli_on_repo_list.yml@main
       with:
-        dataset-list: ${{ needs.get-repos.outputs.dataset_list }}
+        dataset_list: ${{ needs.get-repos.outputs.dataset_list }}
+        clear_old_jsonlds: true
       secrets: inherit

--- a/.github/workflows/run_cli_on_changed_repos.yml
+++ b/.github/workflows/run_cli_on_changed_repos.yml
@@ -9,8 +9,8 @@ on:
   workflow_dispatch:
 
 jobs:
-    get-updated-files:
-      name: Get updated JSONLD files
+    get-updated-repos:
+      name: Get changed OpenNeuroDatasets-JSONLD repos
       runs-on: ubuntu-latest
       # See https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
       outputs:
@@ -64,10 +64,10 @@ jobs:
             fi
 
     call-run-cli-on-repo-list:
-      needs: get-updated-files
+      needs: get-updated-repos
       # Only run this job if the list of changed repos is not empty
-      if: ${{ needs.get-updated-files.outputs.dataset_list != '' }}
+      if: ${{ needs.get-updated-repos.outputs.dataset_list != '' }}
       uses: OpenNeuroDatasets-JSONLD/.github/.github/workflows/run_cli_on_repo_list.yml@main
       with:
-        dataset-list: ${{ needs.get-updated-files.outputs.dataset_list }}
+        dataset-list: ${{ needs.get-updated-repos.outputs.dataset_list }}
       secrets: inherit

--- a/.github/workflows/run_cli_on_changed_repos.yml
+++ b/.github/workflows/run_cli_on_changed_repos.yml
@@ -69,5 +69,5 @@ jobs:
       if: ${{ needs.get-updated-repos.outputs.dataset_list != '' }}
       uses: OpenNeuroDatasets-JSONLD/.github/.github/workflows/run_cli_on_repo_list.yml@main
       with:
-        dataset-list: ${{ needs.get-updated-repos.outputs.dataset_list }}
+        dataset_list: ${{ needs.get-updated-repos.outputs.dataset_list }}
       secrets: inherit

--- a/.github/workflows/run_cli_on_changed_repos.yml
+++ b/.github/workflows/run_cli_on_changed_repos.yml
@@ -45,7 +45,7 @@ jobs:
             done
             echo 'EOF' >> "$GITHUB_OUTPUT"
         
-        # TODO: Push LOG.txt to .github repo?
+        # Upload the log from the sha scraper process for debugging purposes
         - name: Upload log file as artifact
           uses: actions/upload-artifact@v4
           with:

--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -7,15 +7,23 @@ on:
   workflow_call:
     inputs:
       # NOTE: If this input is empty, the workflow should not run
-      dataset-list:
+      dataset_list:
         description: "String representing a list of repos to update"
         required: true
         type: string
+      clear_old_jsonlds:
+        description: "Whether to delete all existing JSONLD files in neurobagel/openneuro-annotations"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   batch-run-cli:
     name: Batch run CLI
     runs-on: ubuntu-latest
+    outputs:
+      were_new_jsonlds_created: ${{ steps.check-jsonlds.outputs.were_new_jsonlds_created }}
+
     steps:
       - name: Generate a token
         id: generate-token
@@ -56,10 +64,19 @@ jobs:
       - name: Run CLI
         working-directory: code
         # Passing input as a file to avoid issues with multiline strings
-        # NOTE: This step also removes the quotes in dataset-list (we add these back inside batch_run_cli.sh)
+        # NOTE: This step also removes the quotes in dataset_list (we add these back inside batch_run_cli.sh)
         run: |
-          echo "${{ inputs.dataset-list }}" > dataset_list.txt
+          echo "${{ inputs.dataset_list }}" > dataset_list.txt
           ./batch_run_cli.sh dataset_list.txt 2>&1 | tee -a LOG.txt
+      
+      - name: Check if new JSONLD files were created
+        id: check-jsonlds
+        run: |
+          if [ -d "code/data/jsonld" ] && [ "$(ls code/data/jsonld)" ]; then
+            echo "were_new_jsonlds_created=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "were_new_jsonlds_created=false" >> "$GITHUB_OUTPUT"
+          fi
       
       # TODO: If this gets too slow, try https://github.com/actions/cache
       - name: Upload JSONLD files as artifacts
@@ -68,6 +85,7 @@ jobs:
           name: jsonld-files
           # NOTE: code/data/jsonld is a temporary directory created by code/run_cli_single_dataset.sh
           path: code/data/jsonld
+          if-no-files-found: ignore
           # TODO: Add a retention policy to delete old artifacts
 
       - name: Upload failed BIDS metadata tables if any
@@ -120,10 +138,15 @@ jobs:
           token: ${{ steps.generate-token.outputs.token }}
 
       - name: Clear existing jsonld files
-        run: rm -f jsonld/*
+        if: ${{ inputs.clear_old_jsonlds }}
+        run: rm jsonld/*
 
+      # NOTE: We need a variable to explicitly check if new JSONLD files were created
+      # because download-artifact doesn't offer an if-no-files-found condition
+      # and would otherwise fail if there is nothing to download.
       - name: Download JSONLD files artifact
         uses: actions/download-artifact@v4
+        if: needs.batch-run-cli.outputs.were_new_jsonlds_created == 'true'
         with:
           name: jsonld-files
           path: jsonld
@@ -134,7 +157,18 @@ jobs:
           name: cli-log-file
           # NOTE: Path must be a directory, not a file
           path: jsonld
-      
+
+      # Sanity check in the case where we want to regenerate JSONLDs for ALL datasets
+      # (i.e., clear_old_jsonlds is true)
+      # but the CLI run failed to produce any new JSONLD files 
+      # - this would most likely indicate a problem on our end.
+      - name: Check that there's at least one JSONLD file
+        run: |
+          if ! find jsonld -type f -name "*.jsonld" | grep -q .; then
+            echo "No JSONLD files remaining in the jsonld/ directory, exiting."
+            exit 1
+          fi
+
       # Configure git to use the GitHub App's bot user
       # https://github.com/actions/create-github-app-token?tab=readme-ov-file#configure-git-cli-for-an-apps-bot-user
       - name: Get GitHub App User ID
@@ -149,8 +183,9 @@ jobs:
           git config --global user.email '${{ steps.get-user-id.outputs.user-id }}+${{ steps.generate-token.outputs.app-slug }}[bot]@users.noreply.github.com'
 
       - name: Commit and push updated JSONLD files
-        # TODO: If there are no JSONLD files to update, skip this step
         run: |
-          git add -A jsonld/*
-          git commit -m "[bot] Update JSONLD files and CLI log"
-          git push origin auto-update-jsonlds
+          if ! git diff --quiet jsonld; then
+            git add -A jsonld
+            git commit -m "[bot] Update JSONLD files and CLI log"
+            git push origin auto-update-jsonlds
+          fi

--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -64,7 +64,9 @@ jobs:
       - name: Run CLI
         working-directory: code
         # Passing input as a file to avoid issues with multiline strings
-        # NOTE: This step also removes the quotes in dataset_list (we add these back inside batch_run_cli.sh)
+        # NOTE: This step doesn't preserve the quotes around SHA values in dataset_list, 
+        # so we add those back inside batch_run_cli.sh so that they appear in sha.txt
+        # how they are returned from the GH API (as a quoted string)
         run: |
           echo "${{ inputs.dataset_list }}" > dataset_list.txt
           ./batch_run_cli.sh dataset_list.txt 2>&1 | tee -a LOG.txt

--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -88,7 +88,7 @@ jobs:
           if-no-files-found: ignore
           # TODO: Add a retention policy to delete old artifacts
 
-      - name: Upload failed BIDS metadata tables if any
+      - name: Upload failed BIDS metadata tables as artifacts
         uses: actions/upload-artifact@v4
         with:
           name: failed-bids-tsvs
@@ -101,6 +101,13 @@ jobs:
         with:
           name: cli-log-file
           path: code/LOG.txt
+
+      - name: Upload list of datasets missing annotations as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: datasets-missing-annotations
+          path: code/datasets_missing_annotations.txt
+          if-no-files-found: ignore
 
       - name: Commit and push updated sha.txt file
         # If sha.txt was not updated (i.e., all datasets failed?), skip this step
@@ -156,6 +163,12 @@ jobs:
         with:
           name: cli-log-file
           # NOTE: Path must be a directory, not a file
+          path: jsonld
+
+      - name: Download list of datasets missing annotations artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: datasets-missing-annotations
           path: jsonld
 
       # Sanity check in the case where we want to regenerate JSONLDs for ALL datasets

--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -96,7 +96,7 @@ jobs:
           path: code/data/failed_bids_tsv
           if-no-files-found: ignore
 
-      - name: Upload log file as artifact
+      - name: Upload CLI log as artifact
         uses: actions/upload-artifact@v4
         with:
           name: cli-log-file

--- a/code/batch_run_cli.sh
+++ b/code/batch_run_cli.sh
@@ -6,37 +6,54 @@
 # A space-separated list where each item is: <repo ID>,<SHA>
 dataset_list_path=$1
 
+update_sha_file() {
+    local repo=$1
+    local sha=$2
+    local old_repo_sha
+
+    # Look for an existing SHA for the repo in sha.txt
+    old_repo_sha=$(grep "$repo" sha.txt)
+
+    # The following section is similar to code in sha_scraper.sh but updates SHAs in sha.txt for a different set of repos
+    # Essentially, for a repo that has *successfully run the CLI*, make sure we now record their most up to date SHA
+    # (i.e., to indicate when the last successful CLI run happened).
+    # To achieve this:
+    # - if the repo DOES already have an entry in sha.txt, we replace (update) the existing SHA with the current SHA
+    # - if the repo DOES NOT already have an entry in sha.txt (meaning this is a newly added repo), add the repo and its SHA
+    if [ -n "$old_repo_sha" ]; then
+        echo "${repo}: Updating SHA in file"
+        sed -i "s/${old_repo_sha}/${repo},${sha}/" sha.txt
+    else
+        echo "${repo}: SHA not found, writing latest SHA to file"
+        echo "${repo},${sha}" >> sha.txt
+    fi
+}
+
 for dataset in $(cat $dataset_list_path); do
     repo=$(echo $dataset | cut -d ',' -f 1)
     sha=\"$(echo $dataset | cut -d ',' -f 2)\"
     echo "Repo info: $repo,$sha"
 
     echo "${repo}: Running the CLI"
-    ./run_cli_single_dataset.sh $repo
+    cli_output=$(./run_cli_single_dataset.sh $repo)
+    cli_exit_code=$?
 
     # Check if the CLI ran successfully
-    if [ $? -eq 0 ]; then
+    if [ $cli_exit_code -eq 0 ]; then
         echo "${repo}: CLI ran successfully!"
-
-        # Look for an existing SHA for the repo in sha.txt
-        old_repo_sha=$(grep "$repo" sha.txt)
-
-        # The following section is similar to code in sha_scraper.sh but updates SHAs in sha.txt for a different set of repos
-        # Essentially, for a repo that has *successfully run the CLI*, make sure we now record their most up to date SHA
-        # (i.e., to indicate when the last successful CLI run happened).
-        # To achieve this:
-        # - if the repo DOES already have an entry in sha.txt, we replace (update) the existing SHA with the current SHA
-        # - if the repo DOES NOT already have an entry in sha.txt (meaning this is a newly added repo), add the repo and its SHA
-        if [ ! -z "$old_repo_sha" ]; then
-            echo "${repo}: Updating SHA in file"
-            sed -i "s/${old_repo_sha}/${repo},${sha}/" sha.txt
-        else
-            echo "${repo}: SHA not found, writing latest SHA to file"
-            echo $repo,$sha >> sha.txt
-        fi
-    # If the CLI failed for the repo, we do not update or add an entry to sha.txt so that
-    # the next time this script is called, the CLI will be attempted again for that repo.
+        update_sha_file "$repo" "$sha"
     else
+        # Look for substring from "...must contain at least one column with Neurobagel annotations" error message
+        # to indicate that data dictionary is missing Neurobagel annotations
+        # (we use a substring to avoid issues with logs being wrapped)
+        if echo "$cli_output" | grep -q "one column with Neurobagel annotations"; then
+            echo "${repo}: participants.json is missing Neurobagel annotations. Saving repo ID to datasets_missing_annotations.txt"
+            echo "$repo" >> datasets_missing_annotations.txt
+            update_sha_file "$repo" "$sha"
+        fi
+        # If the CLI failed for the repo and the dataset was annotated, 
+        # we do not update or add an entry to sha.txt so that the next time this script is called, 
+        # the CLI will be attempted again for that repo.
         echo "${repo}: CLI failed"
     fi
 done

--- a/code/batch_run_cli.sh
+++ b/code/batch_run_cli.sh
@@ -14,8 +14,8 @@ update_sha_file() {
     # Look for an existing SHA for the repo in sha.txt
     old_repo_sha=$(grep "$repo" sha.txt)
 
-    # The following section is similar to code in sha_scraper.sh but updates SHAs in sha.txt for a different set of repos
-    # Essentially, for a repo that has *successfully run the CLI*, make sure we now record their most up to date SHA
+    # The following section is similar to code in sha_scraper.sh, but instead updates SHAs in sha.txt for
+    # each repo that has *successfully run the CLI*, to ensure we now record their most up to date SHA
     # (i.e., to indicate when the last successful CLI run happened).
     # To achieve this:
     # - if the repo DOES already have an entry in sha.txt, we replace (update) the existing SHA with the current SHA
@@ -43,7 +43,8 @@ for dataset in $(cat $dataset_list_path); do
         echo "${repo}: CLI ran successfully!"
         update_sha_file "$repo" "$sha"
     else
-        # Look for substring from "...must contain at least one column with Neurobagel annotations" error message
+        # Look in the error message for substring from 
+        # "...must contain at least one column with Neurobagel annotations"
         # to indicate that data dictionary is missing Neurobagel annotations
         # (we use a substring to avoid issues with logs being wrapped)
         if echo "$cli_output" | grep -q "one column with Neurobagel annotations"; then

--- a/code/run_cli_single_dataset.sh
+++ b/code/run_cli_single_dataset.sh
@@ -51,16 +51,15 @@ bagel pheno \
 bagel bids2tsv --bids-dir ${workdir} --output ${workdir}/${ds_id}_bids.tsv
 
 # NOTE: dataget expects OpenNeuro imaging session paths to be in the format /dsXXXX/sub-XXX/ses-XXX
-bagel bids \
+if ! bagel bids \
     --jsonld-path ${workdir}/pheno.jsonld \
     --bids-table ${workdir}/${ds_id}_bids.tsv \
     --dataset-source-dir "/${ds_id}" \
-    --output ${workdir}/pheno_bids.jsonld
+    --output ${workdir}/pheno_bids.jsonld; then
 
-exit_code=$?
-if (( exit_code != 0 )); then
     cp ${workdir}/${ds_id}_bids.tsv ${failed_bids_tsvs}
     echo "Moved BIDS metadata table for failed dataset to ${failed_bids_tsvs}."
+    exit 1
 fi
 
 cp ${workdir}/pheno_bids.jsonld ${out_jsonld_path}

--- a/code/sha_scraper.sh
+++ b/code/sha_scraper.sh
@@ -52,7 +52,7 @@ touch changed_repos.txt
 for repo in $reposON_LD; do
     # Get the SHA of the latest commit in the repo (NOTE: This will always be from the default branch)
     # TODO: Test if the SHA we grab here changes with a new commit
-    sha=$(curl -L \
+    sha=$(curl -sS -L \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GH_TOKEN}" \
         -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/code/sha_scraper.sh
+++ b/code/sha_scraper.sh
@@ -62,7 +62,7 @@ for repo in $reposON_LD; do
     line=$(grep "$repo" sha.txt)
 
     # If line with repo SHA is found
-    if [ ! -z "$line" ]; then
+    if [ -n "$line" ]; then
         echo "${repo}: SHA found in file"
         old_sha=$(echo $line | cut -d, -f2)
         # if the SHA is not the same as the old one

--- a/code/sha_scraper.sh
+++ b/code/sha_scraper.sh
@@ -39,10 +39,8 @@ do_cli_pheno_files_exist() {
         https://api.github.com/repos/${OWNER}/${repo}/contents/participants.json)
 
     if (( ($participant_tsv_response >= 200 && $participant_tsv_response < 300 ) && ($participant_json_response >= 200 && $participant_json_response < 300 ) )); then
-        # success
         return 0
     else
-        # failure
         return 1
     fi
 }


### PR DESCRIPTION
- Closes #32 

Changes proposed in this PR:
- Fix check for existence of participants.json/participants.tsv in dataset
- Prevent workflow from failing when there are no artifacts to upload/download
- For datasets missing annotations in the participants.json, record IDs in new `datasets_missing_annotations.txt` and update `sha.txt` to prevent CLI re-attempts
- Add boolean workflow input for `run_cli_on_repo_list.sh` for whether all existing JSONLD files should be deleted in neurobagel/openneuro-annotations (i.e., to remove potentially outdated files)
- Add sanity check that there is >=1 JSONLD left in in openneuro-annotations after the CLI runs
- Minor script hygiene improvements, standardize GH wf input names