### PR TITLE
[FIX] Use Python 3.11 in CLI runner workflow for bids2table compatibility

### DIFF
--- a/.github/workflows/run_cli_on_repo_list.yml
+++ b/.github/workflows/run_cli_on_repo_list.yml
@@ -51,10 +51,10 @@ jobs:
           git config --global user.email "<>"
 
       # TODO: Cache Python dependencies
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       
       - name: Install dependencies
         run: |


### PR DESCRIPTION
- Fixes #41 