### PR TITLE
[FIX] Make `run_cli_on_all_repos.yml` only run on repos with required CLI inputs

### DIFF
--- a/.github/workflows/run_cli_on_all_repos.yml
+++ b/.github/workflows/run_cli_on_all_repos.yml
@@ -35,7 +35,7 @@ jobs:
             # The following syntax ensures that "repos" is a multiline string, where each line represents one repo
             # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
             echo 'repos<<EOF' >> "$GITHUB_OUTPUT"
-            for line in $(cat repos.txt); do
+            for line in $(cat repos_for_cli.txt); do
               echo $line >> "$GITHUB_OUTPUT"
             done
             echo 'EOF' >> "$GITHUB_OUTPUT"

--- a/.github/workflows/run_cli_on_all_repos.yml
+++ b/.github/workflows/run_cli_on_all_repos.yml
@@ -15,8 +15,14 @@ jobs:
         - name: Checkout
           uses: actions/checkout@v4
 
-        # This step gets a list of all repos in OpenNeuroDatasets-JSONLD, and fetches each repo's latest SHA
-        # Each repo ID and its corresponding SHA are written to a job output variable "repos"
+        - name: Clear existing sha.txt
+          run: |
+            > code/sha.txt
+
+        # This step gets a list of all repos in OpenNeuroDatasets-JSONLD, and fetches each repo's latest SHA.
+        # If the repo contains the required files for the bagel CLI, the repo ID and its latest SHA are written to a job output variable "repos"
+        # which forms the list the CLI will run on.
+        # Otherwise, the repo SHA is written directly to sha.txt.
         - id: get-repos
           name: Get repos
           env:
@@ -24,29 +30,33 @@ jobs:
           working-directory: code
           # NOTE: When a repo doesn't exist, the curl command complains confusingly: jq: error (at <stdin>:4): Cannot index object with number
           run: |
-            OWNER="OpenNeuroDatasets-JSONLD"
-
-            nRepos=$(gh api graphql -f query='{
-              organization(login: "'"${OWNER}"'" ) {
-                  repositories {
-                      totalCount
-                  }
-              }
-            }' | jq -r '.data.organization.repositories.totalCount')
-            reposON_LD=$(gh repo list "$OWNER" --fork --limit ${nRepos} --json name --jq '.[].name')
+            ./sha_scraper.sh --all-repos 2>&1 | tee -a LOG.txt
 
             # The following syntax ensures that "repos" is a multiline string, where each line represents one repo
             # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
             echo 'repos<<EOF' >> "$GITHUB_OUTPUT"
-            for repo in $reposON_LD; do
-              sha=$(curl -L \
-                -H "Accept: application/vnd.github+json" \
-                -H "Authorization: Bearer ${GH_TOKEN}" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                https://api.github.com/repos/${OWNER}/${repo}/commits | jq .[0].sha)
-              echo $repo,$sha >> "$GITHUB_OUTPUT"
+            for line in $(cat repos.txt); do
+              echo $line >> "$GITHUB_OUTPUT"
             done
             echo 'EOF' >> "$GITHUB_OUTPUT"
+
+        # Upload the log from the sha scraper process for debugging purposes
+        - name: Upload log file as artifact
+          uses: actions/upload-artifact@v4
+          with:
+            name: log-file
+            path: code/LOG.txt
+
+        - name: Commit and push updated sha.txt file
+          # NOTE: git push only has access to whatever branch is currently checked out
+          run: |
+            if ! git diff --quiet code/sha.txt; then
+              git config user.name "GitHub Actions Bot"
+              git config user.email "<>"
+              git add code/sha.txt
+              git commit -m "[bot] Update record of repo SHAs"
+              git push origin main
+            fi
 
     call-run-cli-on-repo-list:
       needs: get-repos

--- a/.github/workflows/run_cli_on_changed_repos.yml
+++ b/.github/workflows/run_cli_on_changed_repos.yml
@@ -1,11 +1,12 @@
-# This workflow runs on a schedule and when manually triggered. It checks for changes to the OpenNeuroDatasets-JSONLD repos, 
+# This workflow runs on a schedule (every day at midnight EST) and when manually triggered. 
+# It checks for changes to the OpenNeuroDatasets-JSONLD repos, 
 # and calls a reusable workflow to run the CLI on repos that have changed *or* are new.
 # The workflow directly updates the sha.txt file for repos whose SHAs have changed but are missing required files for the CLI.
 name: Run CLI on changed repos
 
 on:
   schedule:
-    - cron: '31 12,0 * * *'
+    - cron: '0 5 * * *'
   workflow_dispatch:
 
 jobs:
@@ -40,7 +41,7 @@ jobs:
             # The following syntax ensures that "changed_repos" is a multiline string, where each line represents one repo
             # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings
             echo 'changed_repos<<EOF' >> "$GITHUB_OUTPUT"
-            for line in $(cat changed_repos.txt); do
+            for line in $(cat repos_for_cli.txt); do
               echo $line >> "$GITHUB_OUTPUT"
             done
             echo 'EOF' >> "$GITHUB_OUTPUT"

--- a/code/sha_scraper.sh
+++ b/code/sha_scraper.sh
@@ -6,6 +6,8 @@
 # If both files exist, the repo ID and current SHA are added to a list of datasets to run the CLI on.
 # If a file needed for the CLI is not found, the script only updates the SHA in sha.txt without doing anything else.
 
+flag="$1"
+
 OWNER="OpenNeuroDatasets-JSONLD"
 
 # TODO: Refactor out code to get list of repos in the organization, since we reuse this in run_cli_on_all_repos.yml
@@ -45,8 +47,8 @@ do_cli_pheno_files_exist() {
     fi
 }
 
-# Make empty file to keep track of repos that have changed
-touch changed_repos.txt
+# Make empty file to keep track of repos to run the CLI on
+touch repos_for_cli.txt
 for repo in $reposON_LD; do
     # Get the SHA of the latest commit in the repo (NOTE: This will always be from the default branch)
     # TODO: Test if the SHA we grab here changes with a new commit
@@ -56,38 +58,48 @@ for repo in $reposON_LD; do
         -H "X-GitHub-Api-Version: 2022-11-28" \
         https://api.github.com/repos/${OWNER}/${repo}/commits | jq .[0].sha)
 
-    # Get the line with the old SHA from sha.txt for the repo
-    line=$(grep "$repo" sha.txt)
-
-    # If line with repo SHA is found
-    if [ -n "$line" ]; then
-        echo "${repo}: SHA found in file"
-        old_sha=$(echo $line | cut -d, -f2)
-        # if the SHA is not the same as the old one
-        if [ "$old_sha" != "$sha" ]; then
-            echo "${repo}: latest SHA is different than existing SHA"
-            if do_cli_pheno_files_exist "$repo"; then
-                # Add repo ID and current SHA of repo to a list of datasets to run the CLI on
-                echo "${repo}: Adding to job list for CLI"
-                echo "${repo},${sha}" >> changed_repos.txt
-            else
-                # If files needed for CLI not found, simply replace the old SHA with the new one
-                echo "${repo}: participants.json and/or participants.tsv not found"
-                echo "${repo}: Updating SHA in file"
-                sed -i "s/${line}/${repo},${sha}/" sha.txt
-            fi
-        fi   
-    # If repo not found in file, write current SHA to file 
-    # and add repo to list of datasets to run the CLI on, if the files needed for the CLI are found
-    else
-        echo "${repo}: SHA not found"
-        
+    if [[ "$flag" == "--all-repos" ]]; then
         if do_cli_pheno_files_exist "$repo"; then
             echo "${repo}: Adding to job list for CLI"
-            echo "${repo},${sha}" >> changed_repos.txt
+            echo "${repo},${sha}" >> repos_for_cli.txt
+        else
+            echo "${repo}: Writing latest SHA to file"
+            echo "${repo},${sha}" >> sha.txt
         fi
+    else
+        # Get the line with the old SHA from sha.txt for the repo
+        line=$(grep "$repo" sha.txt)
 
-        echo "${repo}: Writing latest SHA to file"
-        echo "${repo},${sha}" >> sha.txt
+        # If line with repo SHA is found
+        if [ -n "$line" ]; then
+            echo "${repo}: SHA found in file"
+            old_sha=$(echo $line | cut -d, -f2)
+            # if the SHA is not the same as the old one
+            if [ "$old_sha" != "$sha" ]; then
+                echo "${repo}: latest SHA is different than existing SHA"
+                if do_cli_pheno_files_exist "$repo"; then
+                    # Add repo ID and current SHA of repo to a list of datasets to run the CLI on
+                    echo "${repo}: Adding to job list for CLI"
+                    echo "${repo},${sha}" >> repos_for_cli.txt
+                else
+                    # If files needed for CLI not found, simply replace the old SHA with the new one
+                    echo "${repo}: participants.json and/or participants.tsv not found"
+                    echo "${repo}: Updating SHA in file"
+                    sed -i "s/${line}/${repo},${sha}/" sha.txt
+                fi
+            fi   
+        # If repo not found in sha.txt, add repo to list of datasets to run the CLI on if the required input files are found,
+        # otherwise write current SHA to file 
+        else
+            echo "${repo}: SHA not found"
+            if do_cli_pheno_files_exist "$repo"; then
+                echo "${repo}: Adding to job list for CLI"
+                echo "${repo},${sha}" >> repos_for_cli.txt
+            else
+                echo "${repo}: participants.json and/or participants.tsv not found"
+                echo "${repo}: Writing latest SHA to file"
+                echo "${repo},${sha}" >> sha.txt
+            fi
+        fi
     fi
 done


### PR DESCRIPTION
- Fixes #42 
- Fixes #44 

This PR also modifies the cronjob time for `run_cli_on_changed_repos.yml` to 1x day at midnight EST instead of 2x daily, to make it easier to remember when the wf is run and prevent issues if either `run_cli_on_changed_repos.yml` or `run_cli_on_all_repos.yml` need to be manually re-triggered during the day.