### PR TITLE
Create input for max num of datasets to process

### DIFF
--- a/.github/workflows/run_cli_on_all_repos.yml
+++ b/.github/workflows/run_cli_on_all_repos.yml
@@ -4,6 +4,10 @@ name: Run CLI on all repos
 on:
   workflow_dispatch:
     inputs:
+      max_num_datasets:
+        description: "Max number of datasets to run the CLI on. Set to 0 to run on all datasets."
+        required: false
+        default: "180"
       # TODO: We could probably combine reset_sha, reset_failed_datasets, and clear_old_jsonlds into a single input
       # since they should all be set to the same value for any given run.
       reset_sha:
@@ -67,7 +71,7 @@ jobs:
           working-directory: code
           # NOTE: When a repo doesn't exist, the curl command complains confusingly: jq: error (at <stdin>:4): Cannot index object with number
           run: |
-            ./sha_scraper.sh --all-repos 2>&1 | tee -a LOG.txt
+            ./sha_scraper.sh --all-repos ${{ github.event.inputs.max_num_datasets }} 2>&1 | tee -a LOG.txt
 
             # The following syntax ensures that "repos" is a multiline string, where each line represents one repo
             # See: https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#multiline-strings

--- a/code/batch_run_cli.sh
+++ b/code/batch_run_cli.sh
@@ -37,8 +37,10 @@ for dataset in $(cat $dataset_list_path); do
     echo "($count/$total_datasets) Repo info: $repo,$sha"
 
     echo "${repo}: Running the CLI"
-    cli_output=$(./run_cli_single_dataset.sh $repo)
-    cli_exit_code=$?
+    # Capture stderr and stdout but also print to the terminal live
+    # and capture the exit code of run_cli_single_dataset.sh only
+    cli_output=$(./run_cli_single_dataset.sh "$repo" 2>&1 | tee /dev/tty)
+    cli_exit_code=${PIPESTATUS[0]}
 
     # Check if the CLI ran successfully
     if [ $cli_exit_code -eq 0 ]; then

--- a/code/sha_scraper.sh
+++ b/code/sha_scraper.sh
@@ -6,10 +6,12 @@
 # If both files exist, the repo ID and current SHA are added to a list of datasets to run the CLI on.
 # If a file needed for the CLI is not found, the script only updates the SHA in sha.txt without doing anything else.
 
-flag="$1"
+FLAG="$1"
+MAX_DATASETS_FOR_CLI="${2:-0}"
 
 OWNER="OpenNeuroDatasets-JSONLD"
-DATASETS_FOR_CLI_LIMIT=150
+
+echo "Maximum number of datasets to run the CLI on: $MAX_DATASETS_FOR_CLI"
 
 # TODO: Refactor out code to get list of repos in the organization, since we reuse this in run_cli_on_all_repos.yml
 nRepos=$(gh api graphql -f query='{
@@ -59,9 +61,9 @@ for repo in $reposON_LD; do
         -H "X-GitHub-Api-Version: 2022-11-28" \
         https://api.github.com/repos/${OWNER}/${repo}/commits | jq .[0].sha)
 
-    if [[ "$flag" == "--all-repos" ]]; then
-        if [ $(wc -l < repos_for_cli.txt) -eq $DATASETS_FOR_CLI_LIMIT ]; then
-            echo "Reached limit of $DATASETS_FOR_CLI_LIMIT datasets in repos_for_cli.txt."
+    if [[ "$FLAG" == "--all-repos" ]]; then
+        if [ "$MAX_DATASETS_FOR_CLI" -ne 0 ] && [ $(wc -l < repos_for_cli.txt) -eq "$MAX_DATASETS_FOR_CLI" ]; then
+            echo "Reached limit of $MAX_DATASETS_FOR_CLI datasets in repos_for_cli.txt."
             break
         fi
         # When running the CLI on all repos from scratch, we don't compare the SHAs, 


### PR DESCRIPTION
- Default to 180 datasets (somewhat arbitrary), and disable limit when `max_num_datasets=0`
- Restore live printing of STDOUT from `bagel`